### PR TITLE
fix path for images directory

### DIFF
--- a/lib/plugin-static-paths.js
+++ b/lib/plugin-static-paths.js
@@ -39,7 +39,7 @@ const after = (options) => (server, next) => {
       path: "/images/{param*}",
       handler: {
         directory: {
-          path: Path.join(pathPrefix, "images")
+          path: Path.join(pathPrefix, "js/images")
         }
       },
       config


### PR DESCRIPTION
With this [pull](https://github.com/electrode-io/electrode-archetype-react-app/pull/41), this change is needed to make `generator-electrode` generated app images to works on production environment.

This change is needed because by default the output dir for electrode-archetype-react-app is `dist/js`.