### PR TITLE
Update Minimum Lodash Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "inert": "^4.0.1",
-    "lodash": "^4.5.1"
+    "lodash": "^4.14.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Update lodash version in package.json to accept a minimum of `^4.14.0`.

This fixes an error where `4.13.1` was missing the `defaultTo` script, which could cause errors