### PR TITLE
exclusive support for hapi@18 and @hapi/inert

### DIFF
--- a/lib/decor-static-paths.js
+++ b/lib/decor-static-paths.js
@@ -5,7 +5,7 @@ const path = require("path");
 module.exports = function () {
   return {
     plugins: {
-      inert: {
+      "@hapi/inert": {
         priority: 100,
         options: {}
       },

--- a/lib/decor-static-paths.js
+++ b/lib/decor-static-paths.js
@@ -5,7 +5,8 @@ const path = require("path");
 module.exports = function () {
   return {
     plugins: {
-      "@hapi/inert": {
+      inert: {
+        module: "@hapi/inert",
         priority: 100,
         options: {}
       },

--- a/lib/plugin-static-paths.js
+++ b/lib/plugin-static-paths.js
@@ -48,10 +48,8 @@ const after = options => (server, next) => {
   next && next();
 };
 
-function register(server, options, next) {
+function register(server, options) {
   server.dependency("inert", after(options));
-  // istanbul ignore next
-  next && next();
 }
 
 const pkg = require("../package.json");

--- a/lib/plugin-static-paths.js
+++ b/lib/plugin-static-paths.js
@@ -48,7 +48,7 @@ const after = options => (server, next) => {
   next && next();
 };
 
-function hapi16(server, options, next) {
+function register(server, options, next) {
   server.dependency("inert", after(options));
   // istanbul ignore next
   next && next();
@@ -56,12 +56,4 @@ function hapi16(server, options, next) {
 
 const pkg = require("../package.json");
 
-const { universalHapiPlugin } = require("electrode-hapi-compat");
-
-module.exports = universalHapiPlugin(
-  {
-    hapi16,
-    hapi17: hapi16
-  },
-  pkg
-);
+module.exports = {pkg, register};

--- a/lib/plugin-static-paths.js
+++ b/lib/plugin-static-paths.js
@@ -11,7 +11,7 @@ const assert = require("assert");
 // js, images, and html under ${options.pathPrefix}.
 //
 
-const after = options => (server, next) => {
+const after = options => (server) => {
   options = _.defaultTo(options, {});
   const routePrefix = _.get(options, "routePrefix", "");
   const pathPrefix = _.get(options, "pathPrefix", "");
@@ -43,9 +43,6 @@ const after = options => (server, next) => {
       config
     });
   });
-
-  // istanbul ignore next
-  next && next();
 };
 
 function register(server, options) {

--- a/package.json
+++ b/package.json
@@ -31,17 +31,16 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "electrode-hapi-compat": "^1.0.0",
     "lodash": "^4.17.11"
   },
   "devDependencies": {
     "electrode-archetype-njs-module-dev": "^3.0.0",
-    "inert": "^5.0.0",
-    "electrode-server": "^2.0.0",
+    "@hapi/inert": "^5.0.0",
+    "electrode-server": "^3.0.0",
     "superagent": "^3.8.3"
   },
   "peerDependencies": {
-    "inert": "^4.0.0 || ^5.0.0"
+    "@hapi/inert": "^5.0.0"
   },
   "nyc": {
     "all": true,

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "devDependencies": {
     "electrode-archetype-njs-module-dev": "^3.0.0",
-    "@hapi/inert": "^5.0.0",
+    "@hapi/inert": "^5.2.0",
     "electrode-server": "^3.0.0",
     "superagent": "^3.8.3"
   },
   "peerDependencies": {
-    "@hapi/inert": "^5.0.0"
+    "@hapi/inert": "^5.2.0"
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
This should be rebased to a new 3.x.x branch and should not be pulled until then.

Changes:
- Removal of support for hapi < 18
- Removal of dependency on electrode-hapi-compat
- Dependent on @hapi/inert